### PR TITLE
Link OpenSSL statically

### DIFF
--- a/android/jni/libsrc/SDLActivity.java.patch
+++ b/android/jni/libsrc/SDLActivity.java.patch
@@ -1,6 +1,6 @@
---- SDLActivity.java.orginal	2020-12-21 17:44:36.000000000 +0000
-+++ SDLActivity.java	2021-07-31 16:44:17.369775042 +0100
-@@ -165,10 +165,17 @@
+--- SDLActivity.java.original	2021-09-21 09:49:44.967450543 +0200
++++ SDLActivity.java	2021-09-21 09:51:21.307990291 +0200
+@@ -165,10 +165,15 @@
          return new String[] {
              "hidapi",
              "SDL2",
@@ -16,8 +16,6 @@
 +            "iconv",
 +            "GLU",
 +            "myglob",
-+            "ssl",
-+            "crypto",
              "main"
          };
      }

--- a/android/jni/libsrc/openssl-crypto-Android.mk
+++ b/android/jni/libsrc/openssl-crypto-Android.mk
@@ -664,7 +664,9 @@ local_src_files := \
 	x509v3/v3_sxnet.c \
 	x509v3/v3_tlsf.c \
 	x509v3/v3_utl.c \
-	x509v3/v3err.c
+	x509v3/v3err.c \
+	../engines/e_capi.c \
+	../engines/e_padlock.c
 
 local_c_includes := \
 	$(NDK_PROJECT_PATH)/jni/openssl \
@@ -679,13 +681,54 @@ local_c_flags := -DNO_WINDOWS_BRAINDEATH
 
 #######################################
 
-# target
+## target
+#include $(CLEAR_VARS)
+#include $(LOCAL_PATH)/../android-config.mk
+#LOCAL_SRC_FILES += $(local_src_files)
+#LOCAL_CFLAGS += $(local_c_flags)
+#LOCAL_C_INCLUDES += $(local_c_includes)
+#LOCAL_LDLIBS += -lz
+#ifeq ($(TARGET_ARCH),arm)
+#	LOCAL_SRC_FILES += $(arm_src_files)
+#	LOCAL_CFLAGS += $(arm_cflags)
+#else ifeq ($(TARGET_ARCH),arm64)
+#	LOCAL_SRC_FILES += $(arm64_src_files)
+#	LOCAL_CFLAGS += $(arm64_cflags)
+#else
+#	LOCAL_SRC_FILES += $(non_arm_src_files)
+#endif
+#ifeq ($(TARGET_SIMULATOR),true)
+#	# Make valgrind happy.
+#	LOCAL_CFLAGS += -DPURIFY
+#	LOCAL_LDLIBS += -ldl
+#endif
+#LOCAL_MODULE_TAGS := optional
+#LOCAL_MODULE:= libcrypto
+#include $(BUILD_SHARED_LIBRARY)
+
+########################################
+## host shared library
+#ifeq ($(WITH_HOST_DALVIK),true)
+#    include $(CLEAR_VARS)
+#    include $(LOCAL_PATH)/../android-config.mk
+#    LOCAL_SRC_FILES += $(local_src_files)
+#    LOCAL_CFLAGS += $(local_c_flags) -DPURIFY
+#    LOCAL_C_INCLUDES += $(local_c_includes)
+#    LOCAL_SRC_FILES += $(non_arm_src_files)
+#    LOCAL_LDLIBS += -ldl
+#    LOCAL_MODULE_TAGS := optional
+#    LOCAL_MODULE:= libcrypto
+#    include $(BUILD_SHARED_LIBRARY)
+#endif
+
+########################################
+# host static library, which is used by some SDK tools.
+
 include $(CLEAR_VARS)
 include $(LOCAL_PATH)/../android-config.mk
 LOCAL_SRC_FILES += $(local_src_files)
-LOCAL_CFLAGS += $(local_c_flags)
+LOCAL_CFLAGS += $(local_c_flags) -DPURIFY
 LOCAL_C_INCLUDES += $(local_c_includes)
-LOCAL_LDLIBS += -lz
 ifeq ($(TARGET_ARCH),arm)
 	LOCAL_SRC_FILES += $(arm_src_files)
 	LOCAL_CFLAGS += $(arm_cflags)
@@ -695,40 +738,7 @@ else ifeq ($(TARGET_ARCH),arm64)
 else
 	LOCAL_SRC_FILES += $(non_arm_src_files)
 endif
-ifeq ($(TARGET_SIMULATOR),true)
-	# Make valgrind happy.
-	LOCAL_CFLAGS += -DPURIFY
-    LOCAL_LDLIBS += -ldl
-endif
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE:= libcrypto
-include $(BUILD_SHARED_LIBRARY)
-
-#######################################
-# host shared library
-ifeq ($(WITH_HOST_DALVIK),true)
-    include $(CLEAR_VARS)
-    include $(LOCAL_PATH)/../android-config.mk
-    LOCAL_SRC_FILES += $(local_src_files)
-    LOCAL_CFLAGS += $(local_c_flags) -DPURIFY
-    LOCAL_C_INCLUDES += $(local_c_includes)
-    LOCAL_SRC_FILES += $(non_arm_src_files)
-    LOCAL_LDLIBS += -ldl
-    LOCAL_MODULE_TAGS := optional
-    LOCAL_MODULE:= libcrypto
-    include $(BUILD_SHARED_LIBRARY)
-endif
-
-#########################################
-## host static library, which is used by some SDK tools.
-#
-#include $(CLEAR_VARS)
-#include $(LOCAL_PATH)/../android-config.mk
-#LOCAL_SRC_FILES += $(local_src_files)
-#LOCAL_CFLAGS += $(local_c_flags) -DPURIFY
-#LOCAL_C_INCLUDES += $(local_c_includes)
-#LOCAL_SRC_FILES += $(non_arm_src_files)
 #LOCAL_LDLIBS += -ldl
-#LOCAL_MODULE_TAGS := optional
-#LOCAL_MODULE:= libcrypto_static
-#include $(BUILD_STATIC_LIBRARY)
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE:= libcrypto_static
+include $(BUILD_STATIC_LIBRARY)

--- a/android/jni/libsrc/openssl-ssl-Android.mk
+++ b/android/jni/libsrc/openssl-ssl-Android.mk
@@ -55,21 +55,30 @@ include $(CLEAR_VARS)
 include $(LOCAL_PATH)/../android-config.mk
 LOCAL_SRC_FILES += $(local_src_files)
 LOCAL_C_INCLUDES += $(local_c_includes)
-LOCAL_SHARED_LIBRARIES += libcrypto
+LOCAL_STATIC_LIBRARIES += libcrypto_static
 LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE:= libssl
-include $(BUILD_SHARED_LIBRARY)
+LOCAL_MODULE:= libssl_static
+include $(BUILD_STATIC_LIBRARY)
 
-ifeq ($(WITH_HOST_DALVIK),true)
-    include $(CLEAR_VARS)
-    include $(LOCAL_PATH)/../android-config.mk
-    LOCAL_SRC_FILES += $(local_src_files)
-    LOCAL_C_INCLUDES += $(local_c_includes)
-    LOCAL_SHARED_LIBRARIES += libcrypto
-    LOCAL_MODULE_TAGS := optional
-    LOCAL_MODULE:= libssl
-    include $(BUILD_SHARED_LIBRARY)
-endif
+#include $(CLEAR_VARS)
+#include $(LOCAL_PATH)/../android-config.mk
+#LOCAL_SRC_FILES += $(local_src_files)
+#LOCAL_C_INCLUDES += $(local_c_includes)
+#LOCAL_SHARED_LIBRARIES += libcrypto
+#LOCAL_MODULE_TAGS := optional
+#LOCAL_MODULE:= libssl
+#include $(BUILD_SHARED_LIBRARY)
+
+#ifeq ($(WITH_HOST_DALVIK),true)
+#    include $(CLEAR_VARS)
+#    include $(LOCAL_PATH)/../android-config.mk
+#    LOCAL_SRC_FILES += $(local_src_files)
+#    LOCAL_C_INCLUDES += $(local_c_includes)
+#    LOCAL_SHARED_LIBRARIES += libcrypto
+#    LOCAL_MODULE_TAGS := optional
+#    LOCAL_MODULE:= libssl
+#    include $(BUILD_SHARED_LIBRARY)
+#endif
 
 ## ssltest
 #include $(CLEAR_VARS)


### PR DESCRIPTION
An issue was raised in the forums (http://www.eternal-lands.com/forum/index.php?/topic/61508-new-development-version-of-the-android-client/&do=findComment&comment=597504) about the client not running on old versions of Android. The problem is that  the client has the OpenSSL libraries libcrypto.so and libssl.so dynamically linked in, and when the client starts the system version of these libraries are already loaded. These system libs are too old, and miss functions used by the client. Fix this by linking the OpenSSL libraries statically, forcing the client to use the bundled libs.